### PR TITLE
Added line number for blob/blame when selection is empty

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -88,6 +88,10 @@ async function open ( file = false, page? ) {
 
             lines = `#L${selection.start.line + 1}-L${selection.end.line + 1}`;
 
+          } else if (page.match(/^bl(ob|ame)$/)) {
+
+            filePath += `#L${selection.active.line + 1}`;
+
           }
 
         }


### PR DESCRIPTION
If the selection is empty, the line number of the cursor will be used. This mimics the behavior of atom's alt-g o.