### PR TITLE
Prevent `/` in filePath be encoded.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -116,7 +116,7 @@ async function open ( file = false, page? ) {
 
   }
 
-  const url = _.compact ([ repourl, page, encodeURIComponent ( branch ), encodeURIComponent ( filePath ), lines ]).join ( '/' );
+  const url = _.compact ([ repourl, page, encodeURIComponent ( branch ), encodeURIComponent ( filePath ).replace(/%2F/g, '/'), lines ]).join ( '/' );
 
   openPath ( url );
 


### PR DESCRIPTION
convert
`https://github.com/fabiospampinato/vscode-open-in-github/blob/master/src%2Fcommands.ts/#L119`
to
`https://github.com/fabiospampinato/vscode-open-in-github/blob/master/src/commands.ts/#L119`
