### PR TITLE
Add select network protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,15 @@
       "type": "object",
       "title": "Open in GitHub - Configuration",
       "properties": {
+        "openInGitHub.github.protocol": {
+          "type": "string",
+          "enum": [
+            "https",
+            "http"
+          ],
+          "description": "Select network protocol",
+          "default": "https"
+        },
         "openInGitHub.github.domain": {
           "type": "string",
           "description": "Custom GitHub domain",

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ It adds 12 commands to the command palette:
 
 ```js
 {
+  "openInGitHub.github.protocol": "https", // Select network protocol
   "openInGitHub.github.domain": "github.com", // Custom GitHub domain
   "openInGitHub.remote.name": "origin", // Name of the remote repository
   "openInGitHub.remote.branch": "master", // Name of the remote branch

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ const Utils = {
 
       if ( !match ) return;
 
-      return `https://${config.github.domain}/${match[1]}/${match[2]}`;
+      return `${config.github.protocol}://${config.github.domain}/${match[1]}/${match[2]}`;
 
     }
 


### PR DESCRIPTION
In some cases, for example, if the user uses `Custom GitHub domain`, if it is an intranet environment and the network protocol is http, the jump will be wrong.