### PR TITLE
Fixed remote url with subdomain

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -81,7 +81,7 @@ const Git = {
 
     if ( !ref ) return;
 
-    const re = /(\w+\.\w+)[:/]([^/]+)\/(.*?)(?:\.git|\/)?$/;
+    const re = /(\w+(?:\.\w+)+)[:/]([^/]+)\/(.*?)(?:\.git|\/)?$/;
     const match = re.exec ( ref );
 
     if ( !match ) return;


### PR DESCRIPTION
If repo git reomte url with subdomain like this https://git.xxx.com/user-name/repo-name.git.
Before:
The opened url is https://xxx.com/user-name/repo-name (missing subdomain)
After:
The opened url is https://git.xxx.com/user-name/repo-name
<hr />
Some test cases for changed regular

```javascript
const re = /(\w+(?:\.\w+)*\w+\.\w+)[:/]([^/]+)\/(.*?)(?:\.git|\/)?$/;
const ref1 = 'git@github.com:fabiospampinato/vscode-open-in-github.git'
const ref2 = 'https://github.com/fabiospampinato/vscode-open-in-github.git'
const ref3 = 'git@git.xxx.com:user-name/repo-name.git'
const ref4 = 'https://git.xxx.com/user-name/repo-name.git'
const ref5 = 'https://git.yyy.xxx.com/user-name/repo-name.git'
console.log(re.exec(ref1).slice(1,4)); // [ 'github.com', 'fabiospampinato', 'vscode-open-in-github' ]
console.log(re.exec(ref2).slice(1,4)); // same as above
console.log(re.exec(ref3).slice(1,4)); // [ 'git.xxx.com', 'user-name', 'repo-name' ]
console.log(re.exec(ref4).slice(1,4)); // same as above
console.log(re.exec(ref5).slice(1,4)); // [ 'git.yyy.xxx.com', 'user-name', 'repo-name' ]
``` 