### PR TITLE
Remove slash before line number hash in `URL.get()`

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -87,7 +87,9 @@ const URL = {
     branch = encodeURIComponent ( branch );
     filePath = encodeURIComponent ( filePath ).replace ( /%2F/g, '/' );
 
-    const url = [repoUrl, page, branch, commit, filePath, lines].filter ( Boolean ).join ( '/' );
+    let url = [repoUrl, page, branch, commit, filePath].filter ( Boolean ).join ( '/' );
+
+    if ( lines ) url += lines;
 
     return url;
 


### PR DESCRIPTION
This PR removes the unnecessary slash between the file path and the line number hash in `URL.get()`, for example:

```diff
- https://github.com/foo/bar//blob/3c9b61a149384f0969526c96f6cf4d99eb0e44db/README.md/#L10
+ https://github.com/foo/bar//blob/3c9b61a149384f0969526c96f6cf4d99eb0e44db/README.md#L10
                                                                 no more slash here ☝
```

This is because GitHub cannot render the [code snippet preview](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet) of the permalink correctly if there's a slash before the line number hash, for example:


https://github.com/user-attachments/assets/334f96a6-6b65-41e9-918f-fa41cef52742

