### PR TITLE
Fix regex to handle hyphens in domain names

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -81,7 +81,7 @@ const Git = {
 
     if ( !ref ) return;
 
-    const re = /(\w+(?:\.\w+)+)[:/]*([^/]+)\/(.*?)(?:\.git|\/)?$/;
+    const re = /([\w-]+(?:\.[\w-]+)+)[:/]*([^/]+)\/(.*?)(?:\.git|\/)?$/;
     const match = re.exec ( ref );
 
     if ( !match ) return;


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The regex pattern used to parse Git remote URLs didn't support hyphens in domain names. This caused incorrect parsing for enterprise Git instances or self-hosted servers with hyphens in their domains.

### Root Cause
The pattern `\w+` only matches `[a-zA-Z0-9_]`, which excludes the hyphen character `-`. Many valid domain names contain hyphens (e.g., `github-enterprise.com`, `my-gitlab.com`).

### Solution
Changed the domain matching pattern from `\w` to `[\w-]` to include hyphens.

**Before:**
```javascript
const re = /(\w+(?:\.\w+)+)[:/]*([^/]+)\/(.*?)(?:\.git|\/)?$/;
```

**After:**
```javascript
const re = /([\w-]+(?:\.[\w-]+)+)[:/]*([^/]+)\/(.*?)(?:\.git|\/)?$/;
```

### Example
For the Git remote URL: `git@github-account2.com:user/repo.git`

- **Before (❌):** Matched `account2.com` (missing `github-` prefix)
- **After (✅):** Matched `github-account2.com` (correct)
