### PR TITLE
ci: add release workflow for marketplace, openvsx and github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-extension:
+    permissions:
+      id-token: write
+      contents: write
+      actions: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set node
+        uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - run: npx changelogithub
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - run: pnpm install
+
+      - name: Generate .vsix file
+        run: pnpm package
+
+      - name: Publish Extension
+        run: npx vsxpub --no-dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VSCE_PAT: ${{secrets.VSCE_PAT}}
+          OVSX_PAT: ${{secrets.OVSX_PAT}}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Thumbs.db
 dist
 node_modules
 package-lock.json
+pnpm-lock.yaml
+*.vsix

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "clean": "tsex clean",
     "compile": "tsex compile",
     "debug": "code --extensionDevelopmentPath $PWD --inspect-extensions 9222",
-    "package": "vsce package",
+    "package": "vsce package --no-dependencies",
     "prepublishOnly": "scex -bs clean bundle:prod",
     "vscode:prepublish": "scex -bs clean bundle:prod",
     "dev": "scex -bs bundle:dev debug",


### PR DESCRIPTION
### Description

This PR implements automated publishing of the VS Code extension through CI, with simultaneous releases to:
1. Visual Studio Marketplace
2. OpenVSX registry (for open-source VS Code alternatives)
3. GitHub Release page

The implementation will:
- Add CI workflow for automated publishing
- Handle version synchronization across all platforms
- Require `VSCE_PAT` (for VS Marketplace) and `OVSX_PAT` (for OpenVSX) secrets to be configured in the repository


This workflow (triggered on every `push` event with a tag matching `v*`) and [vsxpub](https://github.com/jinghaihan/vsxpub) have been adopted by several VS Code extension repositories, such as:
+ [vscode-pnpm-catalog-lens](https://github.com/antfu/vscode-pnpm-catalog-lens/pull/21)
+ [vscode-iconify](https://github.com/antfu/vscode-iconify/pull/110)
+ [vscode-file-nesting-config](https://github.com/antfu/vscode-file-nesting-config/pull/295)
+ and more

### Additional context

1. use [gh secret set](https://cli.github.com/manual/gh_secret_set) can set secrets by env file 

```sh
gh secret set -f .env
```

2. use [gh-secrets-sync](https://github.com/jinghaihan/gh-secrets-sync) to sync secrets to multiple repos

For managing these secrets across multiple repositories, consider using the [gh-secrets-sync](https://github.com/jinghaihan/gh-secrets-sync) tool which can:
- Be run locally or configured in a central repository
- Synchronize secrets to multiple repositories at once
